### PR TITLE
プロフィールとコンタクトページを追加

### DIFF
--- a/resources/assets/js/components/CommonFooter.vue
+++ b/resources/assets/js/components/CommonFooter.vue
@@ -1,9 +1,7 @@
 <template>
 <div class="Footer container">
     <div class="row">
-        <footer class="fixed-bottom bg-dark p-0 pt-1 pb-1 col-12 text-light text-center">
-            {{ footerDomain }}
-        </footer>
+        <footer class="fixed-bottom bg-dark p-0 pt-1 pb-1 col-12 text-light text-center">{{ footerDomain }}</footer>
     </div>
 </div>
 </template>

--- a/resources/assets/js/components/FrontArticleIndex.vue
+++ b/resources/assets/js/components/FrontArticleIndex.vue
@@ -1,5 +1,10 @@
 <template>
 <div id="FrontArticleIndex" class="container">
+    <div id="Search" class="mb-4">
+        <div class="col-4 col-sm-4 col-md-4 mx-auto">
+            <input type="text" class="form-control text-center p-0" placeholder="しぼりこみけんさく" v-on:keyup.enter="pushFilteredIndex">
+        </div>
+    </div>
     <div class="p-md-3 col-9 col-sm-9 col-md-9 mx-auto">
         <article class="mb-4" v-for="(article, key, index) in articles" :key="index">
             <header>
@@ -87,6 +92,14 @@ export default {
             })
             return filtered
         },
+        pushFilteredIndex(event) {
+            const keyword = encodeURIComponent(event.target.value)
+            if (keyword) {
+                this.$router.push({ path: '/?keyword=' + keyword })
+            } else {
+                this.$router.push({ path: '/' })
+            }
+        }
     }
 }
 </script>

--- a/resources/assets/js/components/FrontContact.vue
+++ b/resources/assets/js/components/FrontContact.vue
@@ -1,0 +1,8 @@
+<template>
+<div id="FrontContact" class="container">
+    <div class="p-md-3 col-9 col-sm-9 col-md-9 mx-auto">
+        <h2>コンタクト</h2>
+        <hr>
+    </div>
+</div>
+</template>

--- a/resources/assets/js/components/FrontHeader.vue
+++ b/resources/assets/js/components/FrontHeader.vue
@@ -4,30 +4,15 @@
         <h1 id="SiteTitle"><router-link :to="'/'">{{ title }}</router-link></h1>
         <p>{{ description }}</p>
         <ul id="Menu">
-            <li class="menu-item"><router-link :to="'/'">Profile</router-link></li>
-            <li class="menu-item"><router-link :to="'/'">Contact</router-link></li>
+            <li class="menu-item"><router-link :to="'/profile'">Profile</router-link></li>
+            <li class="menu-item"><router-link :to="'/contact'">Contact</router-link></li>
         </ul>
         <hr class="col-5 col-sm-5 col-md-2 text-center">
-        <div id="Search" class="mb-4">
-            <div class="col-4 col-sm-4 col-md-4 mx-auto">
-                <input type="text" class="form-control text-center p-0" placeholder="しぼりこみけんさく" v-on:keyup.enter="pushFilteredIndex">
-            </div>
-        </div>
     </header>
 </div>
 </template>
 <script>
 export default {
-    props: ['title', 'description'],
-    methods: {
-        pushFilteredIndex(event) {
-            const keyword = encodeURIComponent(event.target.value)
-            if (keyword) {
-                this.$router.push({ path: '/?keyword=' + keyword })
-            } else {
-                this.$router.push({ path: '/' })
-            }
-        }
-    }
+    props: ['title', 'description']
 }
 </script>

--- a/resources/assets/js/components/FrontHeader.vue
+++ b/resources/assets/js/components/FrontHeader.vue
@@ -1,10 +1,14 @@
 <template>
-<div class="row">
+<div id="FrontHeader" class="row">
     <header class="col-12 col-sm-12 col-md-12 text-center mt-3">
         <h1 id="SiteTitle"><router-link :to="'/'">{{ title }}</router-link></h1>
         <p>{{ description }}</p>
+        <ul id="Menu">
+            <li class="menu-item"><router-link :to="'/'">Profile</router-link></li>
+            <li class="menu-item"><router-link :to="'/'">Contact</router-link></li>
+        </ul>
         <hr class="col-5 col-sm-5 col-md-2 text-center">
-        <div id="search" class="mb-4">
+        <div id="Search" class="mb-4">
             <div class="col-4 col-sm-4 col-md-4 mx-auto">
                 <input type="text" class="form-control text-center p-0" placeholder="しぼりこみけんさく" v-on:keyup.enter="pushFilteredIndex">
             </div>

--- a/resources/assets/js/components/FrontProfile.vue
+++ b/resources/assets/js/components/FrontProfile.vue
@@ -1,0 +1,8 @@
+<template>
+<div id="FrontProfile" class="container">
+    <div class="p-md-3 col-9 col-sm-9 col-md-9 mx-auto">
+        <h2>プロフィール</h2>
+        <hr>
+    </div>
+</div>
+</template>

--- a/resources/assets/js/router.js
+++ b/resources/assets/js/router.js
@@ -27,6 +27,14 @@ const router = new VueRouter({
                     path: 'article/:code',
                     component: require('./components/FrontArticleDetail.vue'),
                 },
+                {
+                    path: 'profile',
+                    component: require('./components/FrontProfile.vue'),
+                },
+                {
+                    path: 'contact',
+                    component: require('./components/FrontContact.vue'),
+                },
             ]
         },
         {

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -25,11 +25,20 @@ a:hover {
     opacity: 0.8;
     text-decoration: none;
 }
+ul,li {
+    margin: 0;
+    padding: 0;
+}
+li {
+    list-style-type: none;
+}
 hr {
     height: 5px;
     border: none;
     border-top: 1px #47a89c solid;
     border-bottom: 1px #47a89c solid;
+    margin-top: 0;
+    margin-bottom: 10px;
 }
 .explain {
     overflow: hidden;
@@ -68,6 +77,19 @@ a.tag:hover {
 }
 #SiteTitle {
     font-weight: bold;
+}
+#Menu {
+    li {
+        display: inline-block;
+        font-size: 1.0rem;
+        font-weight: bold;
+        padding: 10px;
+    }
+}
+#FrontHeader {
+    p {
+        margin-bottom: 0;
+    }
 }
 // ブログ記事詳細のデザイン
 #FrontArticleDetail {


### PR DESCRIPTION
# 概要
- ヘッダーナビを追加
- 検索欄を記事一覧のvueに移動
- プロフィールとコンタクトページを追加